### PR TITLE
Add Sonal's appointment as PGB rep for Baseline

### DIFF
--- a/meetings/2023-06-07.md
+++ b/meetings/2023-06-07.md
@@ -56,3 +56,4 @@ We are also looking into finding an intern that would be interested in building 
     * James - Token Ownership Derived Authorization (TODA) 
         * Jamey to provide update in June (or later) meeting
 * Other business if we have time left over
+    * The Baseline TSC voted to recommend that Sonal Patel be the Baseline TSC representative to the PGB.  The PGB appointed Sonal Patel as recommended.


### PR DESCRIPTION
Added: The Baseline TSC voted to recommend that Sonal Patel be the Baseline TSC representative to the PGB.  The PGB appointed Sonal Patel as recommended.